### PR TITLE
Ajoute une image dans les attributs OpenGraph

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    siteUrl: "https://jaipeurduvaccin.fr",
+    siteUrl: process.env.URL || "https://jaipeurduvaccin.fr",
     title: "J'ai peur du vaccin",
     description:
       "Cette page vise à regrouper les différentes ressources apportant des réponses scientifiques à des questions légitimes.",

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
 import { useStaticQuery, graphql } from "gatsby";
 
+import icon from '../images/icon.png';
+
 const SEO = ({ description, lang, meta, title }) => {
   const { site } = useStaticQuery(
     graphql`
@@ -12,6 +14,7 @@ const SEO = ({ description, lang, meta, title }) => {
             title
             description
             author
+            siteUrl
           }
         }
       }
@@ -35,6 +38,10 @@ const SEO = ({ description, lang, meta, title }) => {
         {
           property: `og:title`,
           content: title,
+        },
+        {
+          property: `og:image`,
+          content: `${site.siteMetadata.siteUrl}${icon}`,
         },
         {
           property: `og:description`,


### PR DESCRIPTION
Permet d'avoir une image lors de la génération de la *Twitter Card*.

L'utilisation de la variable d'environnement process.env.URL permet lors du build de Gatsby, de pouvoir préciser un autre _host_ que `jaipeurduvaccin.fr`. C'est nécessaire pour pouvoir avoir une image sur le bon domaine lorsqu'on teste sur d'autres instances *(par exemple sur jaipeurduvaccin.netlify.app)*.

Le rendu des Twitter Card peut être vérifié sur : https://cards-dev.twitter.com/validator

![image](https://user-images.githubusercontent.com/1846633/126043806-8307212c-d47b-4a5b-96ea-5f253040b47f.png)
